### PR TITLE
Depend on crypto

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,6 @@ defmodule Hlcid.MixProject do
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-
       description: description(),
       package: package(),
       deps: deps(),
@@ -23,7 +22,7 @@ defmodule Hlcid.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :crypto],
       mod: {HLCID.Application, []}
     ]
   end

--- a/test/hlcid_test.exs
+++ b/test/hlcid_test.exs
@@ -5,7 +5,7 @@ defmodule HLCIDTest do
   @valid_base64 ~r"^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
 
   test "can generate ids" do
-    assert ts = HLCID.generate()
+    assert %HLClock.Timestamp{} = HLCID.generate()
   end
 
   test "can encode and decode to base64" do


### PR DESCRIPTION
Fixes warnings in newer elixir versions for `hlcid` not depending directly on `:crypto`. Also fixes a test warning